### PR TITLE
Pin 493 - fix attributeRegistryManagementURL path

### DIFF
--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/agreementprocess/common/system/ApplicationConfiguration.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/agreementprocess/common/system/ApplicationConfiguration.scala
@@ -30,7 +30,7 @@ object ApplicationConfiguration {
   def attributeRegistryManagementURL: String = {
     val partyMgmtURL: String = config.getString("services.attribute-registry-management")
     s"$partyMgmtURL/pdnd-interop-uservice-attribute-registry-management/0.0.1"
-    //    s"https://gateway.interop.pdnd.dev/pdnd-interop-attribute-registry-management/0.0.1"
+    //    s"https://gateway.interop.pdnd.dev/pdnd-interop-uservice-attribute-registry-management/0.0.1"
   }
 
 }


### PR DESCRIPTION
This PR fix the bug related to a wrong endpoint path set in `attributeRegistryManagementURL` function.