### PR TITLE
[PIN-3393] Added test on verifiedAttributesSatisfied for renewal strategies

### DIFF
--- a/lifecycle/src/main/scala/it/pagopa/interop/agreementprocess/lifecycle/AttributesRules.scala
+++ b/lifecycle/src/main/scala/it/pagopa/interop/agreementprocess/lifecycle/AttributesRules.scala
@@ -9,6 +9,7 @@ import it.pagopa.interop.tenantmanagement.client.model.{
   CertifiedTenantAttribute,
   DeclaredTenantAttribute,
   Tenant,
+  TenantVerifier,
   VerifiedTenantAttribute
 }
 
@@ -43,14 +44,14 @@ object AttributesRules {
   ): Boolean = attributesSatisfied(
     eServiceAttributes.verified,
     consumerAttributes
-      .filter(
-        _.verifiedBy.exists(v =>
-          v.id == producerId && ((v.renewal == REVOKE_ON_EXPIRATION && v.extensionDate
-            .exists(ed => ed.isAfter(OffsetDateTimeSupplier.get()))) || v.renewal == AUTOMATIC_RENEWAL)
-        )
-      )
+      .filter(_.verifiedBy.exists(v => v.id == producerId && isNotExpired(v)))
       .map(_.id)
   )
+
+  private def isNotExpired(verifier: TenantVerifier): Boolean = {
+    (verifier.renewal == REVOKE_ON_EXPIRATION && verifier.extensionDate
+      .exists(ed => ed.isAfter(OffsetDateTimeSupplier.get()))) || verifier.renewal == AUTOMATIC_RENEWAL
+  }
 
   def verifiedAttributesSatisfied(agreement: Agreement, eService: EService, consumer: Tenant): Boolean =
     verifiedAttributesSatisfied(agreement.producerId, eService.attributes, consumer.attributes.mapFilter(_.verified))

--- a/lifecycle/src/test/scala/it/pagopa/interop/agreementprocess/lifecycle/AttributesRulesSpec.scala
+++ b/lifecycle/src/test/scala/it/pagopa/interop/agreementprocess/lifecycle/AttributesRulesSpec.scala
@@ -4,6 +4,7 @@ import it.pagopa.interop.agreementmanagement.client.model.Agreement
 import it.pagopa.interop.agreementprocess.lifecycle.AttributesRules._
 import it.pagopa.interop.catalogmanagement.client.model.EService
 import it.pagopa.interop.tenantmanagement.client.model.Tenant
+import it.pagopa.interop.tenantmanagement.client.model.VerificationRenewal.REVOKE_ON_EXPIRATION
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -468,6 +469,53 @@ class AttributesRulesSpec extends AnyWordSpecLike {
       val tenantAttr = Seq(
         SpecData.tenantVerifiedAttribute(attributeId, UUID.randomUUID()),
         SpecData.tenantVerifiedAttribute(verifierId = producerId)
+      )
+
+      val agreement: Agreement = SpecData.agreement.copy(producerId = producerId)
+      val eService: EService   = SpecData.eService.copy(attributes = eServiceAttr)
+      val consumer: Tenant     = SpecData.tenant.copy(attributes = tenantAttr)
+
+      verifiedAttributesSatisfied(agreement, eService, consumer) shouldBe false
+    }
+
+    "return false if at least one single attribute with REVOKE_ON_EXPIRATION is expired" in {
+      val producerId = UUID.randomUUID()
+      val attr1      = UUID.randomUUID()
+      val attr2      = UUID.randomUUID()
+
+      val eServiceAttr = SpecData
+        .catalogVerifiedAttribute()
+        .copy(verified = Seq(SpecData.catalogSingleAttribute(attr1), SpecData.catalogSingleAttribute(attr2)))
+
+      val tenantAttr = Seq(
+        SpecData.tenantVerifiedAttribute(attr1, producerId),
+        SpecData.tenantVerifiedAttribute(id = attr2, verifierId = producerId, renewal = REVOKE_ON_EXPIRATION)
+      )
+
+      val agreement: Agreement = SpecData.agreement.copy(producerId = producerId)
+      val eService: EService   = SpecData.eService.copy(attributes = eServiceAttr)
+      val consumer: Tenant     = SpecData.tenant.copy(attributes = tenantAttr)
+
+      verifiedAttributesSatisfied(agreement, eService, consumer) shouldBe false
+    }
+
+    "return false if at least one group attribute with REVOKE_ON_EXPIRATION is expired" in {
+      val producerId = UUID.randomUUID()
+      val attr1      = UUID.randomUUID()
+      val attr2      = UUID.randomUUID()
+
+      val eServiceAttr = SpecData
+        .catalogVerifiedAttribute()
+        .copy(verified =
+          Seq(
+            SpecData.catalogGroupAttributes(attr1, UUID.randomUUID()),
+            SpecData.catalogGroupAttributes(attr2, UUID.randomUUID())
+          )
+        )
+
+      val tenantAttr = Seq(
+        SpecData.tenantVerifiedAttribute(attr1, producerId),
+        SpecData.tenantVerifiedAttribute(id = attr2, verifierId = producerId, renewal = REVOKE_ON_EXPIRATION)
       )
 
       val agreement: Agreement = SpecData.agreement.copy(producerId = producerId)

--- a/lifecycle/src/test/scala/it/pagopa/interop/agreementprocess/lifecycle/AttributesRulesSpec.scala
+++ b/lifecycle/src/test/scala/it/pagopa/interop/agreementprocess/lifecycle/AttributesRulesSpec.scala
@@ -1,5 +1,6 @@
 package it.pagopa.interop.agreementprocess.lifecycle
 
+import cats.implicits.catsSyntaxOptionId
 import it.pagopa.interop.agreementmanagement.client.model.Agreement
 import it.pagopa.interop.agreementprocess.lifecycle.AttributesRules._
 import it.pagopa.interop.catalogmanagement.client.model.EService
@@ -8,6 +9,7 @@ import it.pagopa.interop.tenantmanagement.client.model.VerificationRenewal.REVOK
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class AttributesRulesSpec extends AnyWordSpecLike {
@@ -489,7 +491,12 @@ class AttributesRulesSpec extends AnyWordSpecLike {
 
       val tenantAttr = Seq(
         SpecData.tenantVerifiedAttribute(attr1, producerId),
-        SpecData.tenantVerifiedAttribute(id = attr2, verifierId = producerId, renewal = REVOKE_ON_EXPIRATION)
+        SpecData.tenantVerifiedAttribute(
+          id = attr2,
+          verifierId = producerId,
+          renewal = REVOKE_ON_EXPIRATION,
+          extensionDate = OffsetDateTime.now().minusDays(3).some
+        )
       )
 
       val agreement: Agreement = SpecData.agreement.copy(producerId = producerId)
@@ -515,7 +522,12 @@ class AttributesRulesSpec extends AnyWordSpecLike {
 
       val tenantAttr = Seq(
         SpecData.tenantVerifiedAttribute(attr1, producerId),
-        SpecData.tenantVerifiedAttribute(id = attr2, verifierId = producerId, renewal = REVOKE_ON_EXPIRATION)
+        SpecData.tenantVerifiedAttribute(
+          id = attr2,
+          verifierId = producerId,
+          renewal = REVOKE_ON_EXPIRATION,
+          extensionDate = OffsetDateTime.now().minusDays(3).some
+        )
       )
 
       val agreement: Agreement = SpecData.agreement.copy(producerId = producerId)

--- a/lifecycle/src/test/scala/it/pagopa/interop/agreementprocess/lifecycle/SpecData.scala
+++ b/lifecycle/src/test/scala/it/pagopa/interop/agreementprocess/lifecycle/SpecData.scala
@@ -62,7 +62,12 @@ object SpecData {
   def tenantDeclaredAttribute(id: UUID = UUID.randomUUID()): TenantAttribute =
     TenantAttribute(declared = Some(DeclaredTenantAttribute(id = id, assignmentTimestamp = timestamp)))
 
-  def tenantVerifiedAttribute(id: UUID = UUID.randomUUID(), verifierId: UUID = UUID.randomUUID()): TenantAttribute =
+  def tenantVerifiedAttribute(
+    id: UUID = UUID.randomUUID(),
+    verifierId: UUID = UUID.randomUUID(),
+    extensionDate: Option[OffsetDateTime] = Some(timestamp),
+    renewal: VerificationRenewal = VerificationRenewal.AUTOMATIC_RENEWAL
+  ): TenantAttribute =
     TenantAttribute(verified =
       Some(
         VerifiedTenantAttribute(
@@ -72,7 +77,8 @@ object SpecData {
             TenantVerifier(
               id = verifierId,
               verificationDate = timestamp,
-              renewal = VerificationRenewal.AUTOMATIC_RENEWAL
+              renewal = renewal,
+              extensionDate = extensionDate
             )
           ),
           revokedBy = Nil


### PR DESCRIPTION
https://pagopa.atlassian.net/browse/PIN-3393

The test were failing with the condition `REVOKE_ON_EXPIRATION AND extensionDate < today`, I think maybe because the `filter` should exclude the attributes that are failing it. 

With that in mind I changed it in the following: `(REVOKE_ON_EXPIRATION AND extensionDate > today) || AUTOMATIC_RENEWAL`.

Let me know if I didn't understand correctly

