### PR TITLE
PIN-4743: Improve getAgreementEServices endpoint query

### DIFF
--- a/src/main/scala/it/pagopa/interop/agreementprocess/api/impl/AgreementApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/agreementprocess/api/impl/AgreementApiServiceImpl.scala
@@ -1293,7 +1293,7 @@ final case class AgreementApiServiceImpl(
     toEntityMarshallerProblem: ToEntityMarshaller[Problem]
   ): Route = authorize(ADMIN_ROLE, API_ROLE, SECURITY_ROLE, SUPPORT_ROLE) {
     val operationLabel =
-      s"Retrieving EServices with consumers $consumersIds, producers $producersIds"
+      s"Retrieving EServices with consumers $consumersIds, producers $producersIds, states $states, offset $offset, limit $limit"
     logger.info(operationLabel)
 
     val result: Future[CompactEServices] = for {

--- a/src/main/scala/it/pagopa/interop/agreementprocess/common/readmodel/ReadModelId.scala
+++ b/src/main/scala/it/pagopa/interop/agreementprocess/common/readmodel/ReadModelId.scala
@@ -1,0 +1,13 @@
+package it.pagopa.interop.agreementprocess.common.readmodel
+
+import it.pagopa.interop.commons.queue.message.Message.uuidFormat
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+import java.util.UUID
+
+final case class ReadModelId(id: UUID)
+
+object ReadModelId {
+  implicit val rmiFormat: RootJsonFormat[ReadModelId] = jsonFormat1(ReadModelId.apply)
+}


### PR DESCRIPTION
Note: the current approach takes all eservice ids from `agreements` collection at once without pagination (`distinct` results cannot be paginated), and then paginates the query on `eservices` collection.
This has been tested in the current worst case scenario (requesting all eservices without filters) in production and the query completes in 1 second.

If the dataset increases significantly this query may need a refactor